### PR TITLE
Update log4j to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>de.mpc.pia</groupId>
 	<artifactId>pia</artifactId>
-	<version>1.4.3</version>
+	<version>1.4.4</version>
 	<name>PIA - Protein Inference Algorithms</name>
 	<url>https://github.com/mpc-bioinformatics/pia</url>
 
@@ -39,7 +39,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-		<log4j2.version>2.17.0</log4j2.version>
+		<log4j2.version>2.17.1</log4j2.version>
 		<junit.version>4.13.1</junit.version>
 		<commons-collections.version>4.1</commons-collections.version>
 		<jmzidentml.version>1.2.11</jmzidentml.version>


### PR DESCRIPTION
Fix: https://nvd.nist.gov/vuln/detail/CVE-2021-44832
Bumping version to 1.4.4